### PR TITLE
Fixed soft reboot when file is sent through bluetooth

### DIFF
--- a/src/com/android/bluetooth/hfp/HeadsetService.java
+++ b/src/com/android/bluetooth/hfp/HeadsetService.java
@@ -347,6 +347,11 @@ public class HeadsetService extends ProfileService {
 
     public List<BluetoothDevice> getConnectedDevices() {
         enforceCallingOrSelfPermission(BLUETOOTH_PERM, "Need BLUETOOTH permission");
+        if (mStateMachine == null) {
+            Log.w(TAG,"mStateMachine is null");
+            return new ArrayList<BluetoothDevice>(0);
+        }
+
         return mStateMachine.getConnectedDevices();
     }
 


### PR DESCRIPTION
Fixed the following bug:
- Bluetooth is off (after the boot). 
- User selects a file in file manager, in menu selectes "Send" and then selects Bluetooth. 
- System pops up a menu to switch bluetooth on.
- User switches bluetooth on and system soft reboots.
